### PR TITLE
Activities: Add stage start_date to API response

### DIFF
--- a/app/views/api/activities/_activities.json.jbuilder
+++ b/app/views/api/activities/_activities.json.jbuilder
@@ -13,6 +13,7 @@ json.activities activities do |activity|
             :film)
   json.name activity.name unless activity.is_a? MediaActivity
   json.stage_name activity.current_stage.name
+  json.stage_date activity.current_stage.start_date
 
   # This might seem excessive. Removing it would require refactor of ActivityRow component
   json.workshops Workshop.sort(activity.workshops), partial: 'api/workshops/workshop', as: :workshop if activity.category == :Workshops

--- a/spec/cypress/integration/translationActivities.spec.js
+++ b/spec/cypress/integration/translationActivities.spec.js
@@ -15,6 +15,7 @@ describe("Translation Activity", () => {
     cy.get("select").select("Genesis");
     cy.contains("Save").click();
     cy.contains("tr", "Genesis").should("contain", "Planned");
+    cy.contains("tr", "Genesis").find('td:nth-child(3)').should('be.empty')
   });
 
   it("Updates the stage", () => {
@@ -43,6 +44,13 @@ describe("Translation Activity", () => {
       cy.contains("Save").click();
       cy.contains("2018-04-02");
     });
+  });
+
+  it("Dates show on refresh", () => {
+    cy.login();
+    cy.visit(hdiPath + "/Translation");
+    cy.contains("tr", "Genesis").find('td:nth-child(3)').should("contain", '2017-05-29');
+    cy.contains("tr", "Ezra").find('td:nth-child(3)').should('contain', '2017-02')
   });
 
   it("Deletes stages", () => {

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -43,6 +43,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
                    title: nil, 
                    participant_ids: [], 
                    stage_name: 'Planned',
+                   stage_date: nil,
                    scripture: nil,
                    film: 'LukeFilm'
                  }, {
@@ -54,6 +55,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
                    title: nil, 
                    participant_ids: [],
                    stage_name: 'Planned',
+                   stage_date: nil,
                    scripture: 'Other',
                    film: nil
                  }], data[:activities])
@@ -71,6 +73,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
                     participant_ids: [@drew_hdi.id, @abanda_hdi.id],
                     name: 'Ezra',
                     stage_name: 'Drafting',
+                    stage_date: '2017-02',
                     scripture: nil,
                     film: nil)
   end
@@ -88,6 +91,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
                    participant_ids: [@kendall_ewondo.id], 
                    name: 'Workshops: Grammar Intro', 
                    stage_name: 'Noun',
+                   stage_date: '2018-01-21',
                    scripture: nil,
                    film: nil,
                    workshops: [{
@@ -122,6 +126,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
                    participant_ids: [@kendall_ewondo.id], 
                    name: 'Research: Lə the Complementizer', 
                    stage_name: 'Research',
+                   stage_date: '2017-12',
                    scripture: nil,
                    film: nil
                  }], data[:activities])


### PR DESCRIPTION
The stage start_date wasn't included in the api response for
language activities. This left the stage start date field blank
on the list of activities on the initial load. However, if you
visited the activity details, it would load the start date into
the component and it would display on the language page after that.

This change adds the start date of the stage to the API call so
that dates are displayed immediately.